### PR TITLE
Maintain scroll position on controller

### DIFF
--- a/addon/components/llama-table.js
+++ b/addon/components/llama-table.js
@@ -210,6 +210,22 @@ var LlamaTable = Em.Component.extend(InboundActions, ResizeColumns, CellTypes, V
 	loadingText: defaultValue('config.loadingText', 'Loading\u2026'),
 
 	/**
+	 * Sync the horizontal scroll position of this table.
+	 * @property {Number} scrollLeft
+	 * @optional
+	 * @default 0
+	 */
+	scrollLeft: defaultValue('config.scrollLeft', 0),
+
+	/**
+	 * Sync the vertical scroll position of this table.
+	 * @property {Number} scrollTop
+	 * @optional
+	 * @default 0
+	 */
+	scrollTop: defaultValue('config.scrollTop', 0),
+
+	/**
 	 * Table view. Contains header and footer.
 	 * @property {Ember.View} tableView
 	 */

--- a/addon/components/llama-table.js
+++ b/addon/components/llama-table.js
@@ -338,14 +338,18 @@ var LlamaTable = Em.Component.extend(InboundActions, ResizeColumns, CellTypes, V
 
 	actions: {
 		scrollX: function (pos) {
-			this.get('headerView').$().css('marginLeft', -pos);
+			this.set('scrollLeft', pos);
 		},
-		scrollY: function () {
-			// no-op
+		scrollY: function (pos) {
+			this.set('scrollTop', pos);
 		},
 		syncScroll: function () {
-			var pos = this.get('tableView.bodyView').$().scrollLeft();
-			this.send('scrollX', pos);
+			var body = this.get('tableView.bodyView');
+			var $body = body.$();
+			if ($body && $body.length > 0) {
+				this.set('scrollLeft', $body.scrollLeft());
+				this.set('scrollTop', $body.scrollTop());
+			}
 		},
 		sortBy: function (column) {
 			var sortProperties = this.get('sortProperties');

--- a/addon/views/llama-body.js
+++ b/addon/views/llama-body.js
@@ -8,6 +8,8 @@ var LlamaBody = Em.ContainerView.extend(ScrollXYMixin, {
 	classNames: ['llama-body'],
 	isEmpty: alias('controller.isEmpty'),
 	isLoading: alias('controller.isLoading'),
+	scrollLeft: alias('controller.scrollLeft'),
+	scrollTop: alias('controller.scrollTop'),
 
 	columngroups: null,
 	rows: null,
@@ -70,12 +72,20 @@ var LlamaBody = Em.ContainerView.extend(ScrollXYMixin, {
 		}
 	}).on('init'),
 
+	updateScrollPosition: observer('didInsertElement', function () {
+		var $el;
+		if ($el && $el.length > 0) {
+			$el.scrollLeft(this.get('scrollLeft'));
+			$el.scrollTop(this.get('scrollTop'));
+		}
+	}),
+
 	actions: {
 		scrollX: function (pos) {
-			this.get('controller').send('scrollX', pos);
+			this.set('scrollLeft', pos);
 		},
 		scrollY: function (pos) {
-			this.get('controller').send('scrollY', pos);
+			this.set('scrollTop', pos);
 		}
 	}
 });

--- a/addon/views/llama-body.js
+++ b/addon/views/llama-body.js
@@ -73,10 +73,10 @@ var LlamaBody = Em.ContainerView.extend(ScrollXYMixin, {
 	}).on('init'),
 
 	updateScrollPosition: observer('didInsertElement', function () {
-		var $el;
-		if ($el && $el.length > 0) {
-			$el.scrollLeft(this.get('scrollLeft'));
-			$el.scrollTop(this.get('scrollTop'));
+		var $body = this.$();
+		if ($body && $body.length > 0) {
+			$body.scrollLeft(this.get('scrollLeft'));
+			$body.scrollTop(this.get('scrollTop'));
 		}
 	}),
 

--- a/addon/views/llama-header.js
+++ b/addon/views/llama-header.js
@@ -19,7 +19,7 @@ var LlamaHeader = Em.CollectionView.extend({
 		return this._super(View, attrs);
 	},
 
-	updateScroll: observer('scrollLeft', function () {
+	updateScrollPosition: observer('scrollLeft', function () {
 		var $header = this.$();
 		if ($header && $header.length > 0) {
 			$header.css('marginLeft', this.get('scrollLeft') * -1);

--- a/addon/views/llama-header.js
+++ b/addon/views/llama-header.js
@@ -20,9 +20,9 @@ var LlamaHeader = Em.CollectionView.extend({
 	},
 
 	updateScroll: observer('scrollLeft', function () {
-		var $el = this.$();
-		if ($el && $el.length > 0) {
-			$el.css('marginLeft', this.get('scrollLeft') * -1);
+		var $header = this.$();
+		if ($header && $header.length > 0) {
+			$header.css('marginLeft', this.get('scrollLeft') * -1);
 		}
 	}).on('didInsertElement')
 });

--- a/addon/views/llama-header.js
+++ b/addon/views/llama-header.js
@@ -1,6 +1,7 @@
 import Em from 'ember';
 var get = Em.get;
 var set = Em.set;
+var observer = Em.observer;
 var alias = Em.computed.alias;
 
 var LlamaHeader = Em.CollectionView.extend({
@@ -8,6 +9,7 @@ var LlamaHeader = Em.CollectionView.extend({
 	itemViewClass: alias('controller.HeaderColumngroupView'),
 	columngroupViews: alias('childViews'),
 	contentBinding: 'columngroups',
+	scrollLeft: alias('controller.scrollLeft'),
 
 	columngroups: null,
 
@@ -15,7 +17,14 @@ var LlamaHeader = Em.CollectionView.extend({
 		var columns = get(attrs, 'content');
 		set(attrs, 'columns', columns);
 		return this._super(View, attrs);
-	}
+	},
+
+	updateScroll: observer('scrollLeft', function () {
+		var $el = this.$();
+		if ($el && $el.length > 0) {
+			$el.css('marginLeft', this.get('scrollLeft') * -1);
+		}
+	}).on('didInsertElement')
 });
 
 export default LlamaHeader;


### PR DESCRIPTION
Scroll left/top position of body in table is maintained by controller. The header view now observes this new scroll left property for synchronising horizontal scroll position.

This change will allow new child views to synchronise their positions as well with minimal effort -- specifically the new footer view.