### PR TITLE
Allow footer controller instance to be passed in

### DIFF
--- a/addon/views/llama-footer.js
+++ b/addon/views/llama-footer.js
@@ -19,12 +19,16 @@ var LlamaFooter = Em.CollectionView.extend({
 		if (old) {
 			old.destroy();
 		}
-		var Constructor = this.get('controller.footerController');
-		var instance;
-		if (typeof Constructor === 'function') {
+		var footerController = this.get('controller.footerController');
+		var Constructor, instance;
+		if (typeof footerController === 'function') {
+			Constructor = footerController;
 			instance = Constructor.create({
 				content: this.get('rows')
 			});
+		}
+		else if (footerController) {
+			instance = footerController;
 		}
 		return instance;
 	}),


### PR DESCRIPTION
This change allows footer controllers to be specified as an instance. Previously only constructors were allowed and instances were created by Llama Table itself.

This new functionality is completely optional and constructors are still accepted.