### PR TITLE
Fix package versions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "llama-table",
   "dependencies": {
-    "jquery": "^1.11.1",
+    "jquery": "~1.11",
     "ember": "1.11.3",
     "ember-resolver": "~0.1.11",
     "loader.js": "ember-cli/loader.js#1.0.1",

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "llama-table",
   "dependencies": {
     "jquery": "~1.11",
-    "ember": "1.11.3",
+    "ember": "~1.12",
     "ember-resolver": "~0.1.11",
     "loader.js": "ember-cli/loader.js#1.0.1",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",


### PR DESCRIPTION
The jQuery and Ember versions are too loosely defined and newer minors are breaking Llama Table. This change makes sure the installed versions are specifically aligned to Llama Table's requirements.