### PR TITLE
patch for fixing error when no sortProperties

### DIFF
--- a/addon/components/llama-header-cell/component.js
+++ b/addon/components/llama-header-cell/component.js
@@ -41,6 +41,9 @@ var LlamaHeaderCell = LlamaCell.extend({
 	sortByThis: computed('sortProperties.firstObject', 'column.sortBy', {
 		get: function () {
 			const sortBy = this.get('sortProperties.firstObject');
+			if (Em.isEmpty(sortBy)) {
+				return false;
+			}
 			const sortedColumn = String(sortBy).split(':', 1)[0];
 			const thisColumn = this.get('column.sortBy');
 			return sortedColumn === thisColumn;

--- a/addon/components/llama-header-cell/component.js
+++ b/addon/components/llama-header-cell/component.js
@@ -41,7 +41,7 @@ var LlamaHeaderCell = LlamaCell.extend({
 	sortByThis: computed('sortProperties.firstObject', 'column.sortBy', {
 		get: function () {
 			const sortBy = this.get('sortProperties.firstObject');
-			const sortedColumn = sortBy.split(':', 1)[0];
+			const sortedColumn = String(sortBy).split(':', 1)[0];
 			const thisColumn = this.get('column.sortBy');
 			return sortedColumn === thisColumn;
 		},


### PR DESCRIPTION
when no `sortProperties` is defined, `sortBy` is undefined which causes an error when use `String.split`
This PR added extra sanity checks.
